### PR TITLE
Updated the Go version from 1.22 to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/enthus-golang/ingram
 
-go 1.22
+go 1.24
 
 require (
 	github.com/go-playground/validator/v10 v10.22.0


### PR DESCRIPTION
This pull request updates the Go module configuration to use a newer version of the Go programming language.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.22` to `1.24` to align with the latest features and improvements in the Go language.